### PR TITLE
返回信息中加入干支

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ dist/
 .vscode/*
 !.vscode/extensions.json
 .idea
+
+# AI
+.opencode/
+.trellis/
+AGENTS.md

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@modelcontextprotocol/sdk": "^1.7.0",
     "dayjs": "^1.11.13",
     "dayjs-plugin-lunar": "^1.4.0",
-    "tyme4ts": "1.3.4",
+    "tyme4ts": "1.4.5",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.1"
   },

--- a/src/almanac.ts
+++ b/src/almanac.ts
@@ -32,6 +32,11 @@ export function getHourlyAlmanac(date: dayjs.Dayjs): AlmanacContentItem {
       `财神${handleDirection(heavenStem.getWealthDirection().toString())}`,
       `福神${handleDirection(heavenStem.getMascotDirection().toString())}`,
     ],
+    [ContentType.干支]: {
+        年: lunarHour.getEightChar().getYear().toString(),
+        月: lunarHour.getEightChar().getMonth().toString(),
+        日: lunarHour.getEightChar().getDay().toString(),
+      },
   };
 }
 
@@ -50,6 +55,7 @@ export function getDailyAlmanac(
   const lunarDay = parsedDate.toLunarDay();
   const solarDay = lunarDay.getSolarDay();
   const sixtyCycle = lunarDay.getSixtyCycle();
+  const heavenStem = sixtyCycle.getHeavenStem();
   const earthBranch = sixtyCycle.getEarthBranch();
   const twentyEightStar = lunarDay.getTwentyEightStar();
   const gods = lunarDay.getGods().reduce(
@@ -84,6 +90,11 @@ export function getDailyAlmanac(
       [ContentType.吉神宜趋]: gods.auspicious,
       [ContentType.凶煞宜忌]: gods.inauspicious,
       [ContentType.彭祖百忌]: `${sixtyCycle.getHeavenStem().getPengZuHeavenStem()} ${earthBranch.getPengZuEarthBranch()}`,
+      [ContentType.干支]: {
+        年: lunarDay.getThreePillars().getYear().toString(),
+        月: lunarDay.getThreePillars().getMonth().toString(),
+        日: lunarDay.getThreePillars().getDay().toString(),
+      },
     },
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export enum ContentType {
   凶煞宜忌 = '凶煞宜忌',
   彭祖百忌 = '彭祖百忌',
   方位 = '方位',
+  干支 = '干支',
 }
 
 export enum TabooType {
@@ -22,7 +23,7 @@ export enum TabooType {
 }
 
 export interface AlmanacContentItem {
-  [key: string]: string | string[];
+  [key: string]: string | string[] | { 年: string; 月: string; 日: string };
 }
 
 export interface DailyAlmanac {


### PR DESCRIPTION
## 变更内容
- 更新了 tyme4ts 的版本到 1.4.5
- 返回信息中加入`干支`信息

返回示例

```
*   **公历**：2024年5月22日（周三）
*   **农历**：甲辰年四月十五
*   **干支**：
    *   年：**甲辰**
    *   月：**己巳**
    *   日：**丙戌**
```